### PR TITLE
Option to render class name scalars using PHP 5.5+ class-keyword.

### DIFF
--- a/src/Writer/PhpArray.php
+++ b/src/Writer/PhpArray.php
@@ -71,6 +71,14 @@ class PhpArray extends AbstractWriter
     }
 
     /**
+     * @return boolean
+     */
+    public function getUseClassNameScalars()
+    {
+        return $this->useClassNameScalars;
+    }
+
+    /**
      * toFile(): defined by Writer interface.
      *
      * @see    WriterInterface::toFile()

--- a/src/Writer/PhpArray.php
+++ b/src/Writer/PhpArray.php
@@ -42,8 +42,8 @@ class PhpArray extends AbstractWriter
         ];
 
         return "<?php\n" .
-               "return " . $arraySyntax['open'] . "\n" . $this->processIndented($config, $arraySyntax) .
-               $arraySyntax['close'] . ";\n";
+        "return " . $arraySyntax['open'] . "\n" . $this->processIndented($config, $arraySyntax) .
+        $arraySyntax['close'] . ";\n";
     }
 
     /**
@@ -148,8 +148,8 @@ class PhpArray extends AbstractWriter
                 } else {
                     $indentLevel++;
                     $arrayString .= $arraySyntax['open'] . "\n"
-                                  . $this->processIndented($value, $arraySyntax, $indentLevel)
-                                  . str_repeat(self::INDENT_STRING, --$indentLevel) . $arraySyntax['close'] . ",\n";
+                        . $this->processIndented($value, $arraySyntax, $indentLevel)
+                        . str_repeat(self::INDENT_STRING, --$indentLevel) . $arraySyntax['close'] . ",\n";
                 }
             } elseif (is_object($value)) {
                 $arrayString .= var_export($value, true) . ",\n";
@@ -206,13 +206,16 @@ class PhpArray extends AbstractWriter
      */
     protected function fqnStringToClassNameScalar($string)
     {
-        // We actually don't know yet, whether it's a FQN, but we assume.
-        if (false === ($fqnString = $this->ensureFqn($string))) {
+        if (strlen($string) < 1) {
             return false;
         }
 
-        if ($this->checkStringIsFqn($fqnString)) {
-            return $fqnString . '::class';
+        if ($string[0] !== '\\') {
+            $string = '\\' . $string;
+        }
+
+        if ($this->checkStringIsFqn($string)) {
+            return $string . '::class';
         }
 
         return false;
@@ -231,25 +234,5 @@ class PhpArray extends AbstractWriter
         }
 
         return class_exists($string) || interface_exists($string) || trait_exists($string);
-    }
-
-    /**
-     * Ensures an assumed fqn string has a trailing backslash.
-     * Returns false if string is empty.
-     *
-     * @param string $string
-     * @return string|bool
-     */
-    protected function ensureFqn($string)
-    {
-        if (strlen($string) < 1) {
-            return false;
-        }
-
-        if ($string[0] !== '\\') {
-            return '\\' . $string;
-        }
-
-        return $string;
     }
 }

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -133,23 +133,27 @@ class PhpArrayTest extends AbstractWriterTestCase
         $this->assertFalse(class_exists($dummyFqnB, false), $message);
 
         $config = new Config([
+            "\\~" => 'bar',
             'PhpArrayTest' => 'PhpArrayTest',
             '' => 'emptyString',
             'TestAssets\DummyClass' => 'foo',
             $dummyFqnA => [
                 'fqnValue' => $dummyFqnB
-            ]
+            ],
+            '\\' . $dummyFqnA => ''
         ]);
 
         $expected = <<< ECS
 <?php
 return array(
+    '\\\~' => 'bar',
     'PhpArrayTest' => 'PhpArrayTest',
     '' => 'emptyString',
     'TestAssets\\\\DummyClass' => 'foo',
-    $dummyFqnA::class => array(
-        'fqnValue' => $dummyFqnB::class,
+    \\$dummyFqnA::class => array(
+        'fqnValue' => \\$dummyFqnB::class,
     ),
+    \\$dummyFqnA::class => '',
 );
 
 ECS;

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -116,8 +116,48 @@ class PhpArrayTest extends AbstractWriterTestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testRenderWithClassNameScalarsEnabled()
+    {
+        $this->writer->setUseClassNameScalars(true);
+
+        $dummyFqnA = 'ZendTest\Config\Writer\TestAssets\DummyClassA';
+        $dummyFqnB = 'ZendTest\Config\Writer\TestAssets\DummyClassB';
+
+        // Dummy classes should not be loaded prior this test
+        $this->assertFalse(class_exists($dummyFqnA, false));
+        $this->assertFalse(class_exists($dummyFqnB, false));
+
+        $config = new Config([
+            'PhpArrayTest' => 'PhpArrayTest',
+            '' => 'emptyString',
+            'TestAssets\DummyClass' => 'foo',
+            $dummyFqnA => [
+                'fqnValue' => $dummyFqnB
+            ]
+        ]);
+
+        $expected = "<?php\n";
+        $expected .= "return array(\n";
+        $expected .= "    'PhpArrayTest' => 'PhpArrayTest',\n";
+        $expected .= "    '' => 'emptyString',\n";
+        $expected .= "    'TestAssets\\\\DummyClass' => 'foo',\n";
+        $expected .= "    $dummyFqnA::class => array(\n";
+        $expected .= "        'fqnValue' => $dummyFqnB::class,\n";
+        $expected .= "    ),\n";
+        $expected .= ");\n";
+
+        $result = $this->writer->toString($config);
+
+        $this->assertSame($expected, $result);
+    }
+
     public function testSetUseBracketArraySyntaxReturnsFluentInterface()
     {
         $this->assertSame($this->writer, $this->writer->setUseBracketArraySyntax(true));
+    }
+
+    public function testSetUseClassNameScalarsReturnsFluentInterface()
+    {
+        $this->assertSame($this->writer, $this->writer->setUseClassNameScalars(true));
     }
 }

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -139,16 +139,18 @@ class PhpArrayTest extends AbstractWriterTestCase
             ]
         ]);
 
-        $expected = "<?php\n";
-        $expected .= "return array(\n";
-        $expected .= "    'PhpArrayTest' => 'PhpArrayTest',\n";
-        $expected .= "    '' => 'emptyString',\n";
-        $expected .= "    'TestAssets\\\\DummyClass' => 'foo',\n";
-        $expected .= "    $dummyFqnA::class => array(\n";
-        $expected .= "        'fqnValue' => $dummyFqnB::class,\n";
-        $expected .= "    ),\n";
-        $expected .= ");\n";
+        $expected = <<< ECS
+<?php
+return array(
+    'PhpArrayTest' => 'PhpArrayTest',
+    '' => 'emptyString',
+    'TestAssets\\\\DummyClass' => 'foo',
+    $dummyFqnA::class => array(
+        'fqnValue' => $dummyFqnB::class,
+    ),
+);
 
+ECS;
         $result = $this->writer->toString($config);
 
         $this->assertSame($expected, $result);

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -11,6 +11,8 @@ namespace ZendTest\Config\Writer;
 
 use Zend\Config\Writer\PhpArray;
 use Zend\Config\Config;
+use ZendTest\Config\Writer\TestAssets\DummyClassA;
+use ZendTest\Config\Writer\TestAssets\DummyClassB;
 use ZendTest\Config\Writer\TestAssets\PhpReader;
 
 /**
@@ -120,8 +122,8 @@ class PhpArrayTest extends AbstractWriterTestCase
     {
         $this->writer->setUseClassNameScalars(true);
 
-        $dummyFqnA = 'ZendTest\Config\Writer\TestAssets\DummyClassA';
-        $dummyFqnB = 'ZendTest\Config\Writer\TestAssets\DummyClassB';
+        $dummyFqnA = DummyClassA::class;
+        $dummyFqnB = DummyClassB::class;
 
         // Dummy classes should not be loaded prior this test
         $message = sprintf('class %s should not be loaded prior test', $dummyFqnA);

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -124,8 +124,11 @@ class PhpArrayTest extends AbstractWriterTestCase
         $dummyFqnB = 'ZendTest\Config\Writer\TestAssets\DummyClassB';
 
         // Dummy classes should not be loaded prior this test
-        $this->assertFalse(class_exists($dummyFqnA, false));
-        $this->assertFalse(class_exists($dummyFqnB, false));
+        $message = sprintf('class %s should not be loaded prior test', $dummyFqnA);
+        $this->assertFalse(class_exists($dummyFqnA, false), $message);
+
+        $message = sprintf('class %s should not be loaded prior test', $dummyFqnB);
+        $this->assertFalse(class_exists($dummyFqnB, false), $message);
 
         $config = new Config([
             'PhpArrayTest' => 'PhpArrayTest',

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -160,11 +160,7 @@ ECS;
 
     public function testUseClassNameScalarsIsFalseByDefault()
     {
-        $reflection = new \ReflectionClass(PhpArray::class);
-        $property = $reflection->getProperty('useClassNameScalars');
-        $property->setAccessible(true);
-
-        $this->assertFalse($property->getValue($this->writer), 'useClassNameScalars should be false by default');
+        $this->assertFalse($this->writer->getUseClassNameScalars(), 'useClassNameScalars should be false by default');
     }
 
     public function testSetUseBracketArraySyntaxReturnsFluentInterface()

--- a/test/Writer/PhpArrayTest.php
+++ b/test/Writer/PhpArrayTest.php
@@ -156,6 +156,15 @@ ECS;
         $this->assertSame($expected, $result);
     }
 
+    public function testUseClassNameScalarsIsFalseByDefault()
+    {
+        $reflection = new \ReflectionClass(PhpArray::class);
+        $property = $reflection->getProperty('useClassNameScalars');
+        $property->setAccessible(true);
+
+        $this->assertFalse($property->getValue($this->writer), 'useClassNameScalars should be false by default');
+    }
+
     public function testSetUseBracketArraySyntaxReturnsFluentInterface()
     {
         $this->assertSame($this->writer, $this->writer->setUseBracketArraySyntax(true));

--- a/test/Writer/TestAssets/DummyClassA.php
+++ b/test/Writer/TestAssets/DummyClassA.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Config\Writer\TestAssets;
+
+class DummyClassA
+{
+}

--- a/test/Writer/TestAssets/DummyClassB.php
+++ b/test/Writer/TestAssets/DummyClassB.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Config\Writer\TestAssets;
+
+class DummyClassB
+{
+}


### PR DESCRIPTION
As proposed in #5.

I thought about adding an option to toggle the autoload usage, but I could not find any reason why you would want to set it. If you want it to be added, let me know.

I did not add a trailing slash to resolved ::class-literals, because: 
* The rendered output does not include any namespacing.
* Even if the rendered output is included in another namespace, PHP does not transfer the context to the included file.

Close #4
Close #5