### PR TITLE
Hint on stdlib as `dev-develop as 2.8.0`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": "dev-develop as 2.8.0"
     },
     "require-dev": {
         "zendframework/zend-filter": "~2.5",


### PR DESCRIPTION
Allows zend-stdlib to work when testing against zend-config, while continuing to allow its own dev requirements to install (as they hint against stdlib ~2.5).