### PR TITLE
Minor updates to servicemanager compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "zendframework/zend-filter": "dev-develop as 2.6.0",
         "zendframework/zend-i18n": "dev-develop as 2.6.0",
         "zendframework/zend-json": "dev-develop as 2.7.0",
-        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/ReaderPluginManager.php
+++ b/src/ReaderPluginManager.php
@@ -74,11 +74,15 @@ class ReaderPluginManager extends AbstractPluginManager
      * Proxies to `validate()`.
      *
      * @param mixed $instance
-     * @throws InvalidServiceException
+     * @throws Exception\InvalidArgumentException
      */
     public function validatePlugin($instance)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($instance);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     public function __construct(ContainerInterface $container, array $config = [])

--- a/src/WriterPluginManager.php
+++ b/src/WriterPluginManager.php
@@ -75,11 +75,15 @@ class WriterPluginManager extends AbstractPluginManager
      * Proxies to `validate()`.
      *
      * @param mixed $instance
-     * @throws InvalidServiceException
+     * @throws Exception\InvalidArgumentException
      */
     public function validatePlugin($instance)
     {
-        $this->validate($instance);
+        try {
+            $this->validate($instance);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     public function __construct(ContainerInterface $container, array $config = [])

--- a/test/ReaderPluginManagerCompatibilityTest.php
+++ b/test/ReaderPluginManagerCompatibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Config;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Config\Exception\InvalidArgumentException;
+use Zend\Config\ReaderPluginManager;
+use Zend\Config\Reader\ReaderInterface;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ReaderPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ReaderPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return ReaderInterface::class;
+    }
+}

--- a/test/WriterPluginManagerCompatibilityTest.php
+++ b/test/WriterPluginManagerCompatibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Config;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Config\Exception\InvalidArgumentException;
+use Zend\Config\WriterPluginManager;
+use Zend\Config\Writer\AbstractWriter;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class WriterPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new WriterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return AbstractWriter::class;
+    }
+}


### PR DESCRIPTION
Adds two new test cases:

- `ReaderPluginManagerCompatibilityTest`
- `WriterPluginManagerCompatibilityTest`

each of which compose the `CommonPluginManagerTrait` to allow testing v2 + v3 compatibility.

Also updates the two plugin manager implementations to throw the original v2 exception types when under v2.