### PR TITLE
Reduce and stabilize dependencies required for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,21 @@ matrix:
         - EXECUTE_CS_CHECK=true
     - php: 5.5
       env:
-        - SERVICE_MANAGER_VERSION='^2.7.3'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
     - php: 5.6
       env:
-        - SERVICE_MANAGER_VERSION='^2.7.3'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: 7
     - php: 7
       env:
-        - SERVICE_MANAGER_VERSION='^2.7.3'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
     - php: hhvm
     - php: hhvm
       env:
-        - SERVICE_MANAGER_VERSION='^2.7.3'
+        - SERVICE_MANAGER_VERSION='^2.7.5'
   allow_failures:
     - php: hhvm
 
@@ -46,7 +46,8 @@ before_install:
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
+  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update "zendframework/zend-i18n" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "zendframework/zend-stdlib": "dev-develop as 2.8.0"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-filter": "dev-develop as 2.6.0",
-        "zendframework/zend-i18n": "dev-develop as 2.6.0",
-        "zendframework/zend-json": "dev-develop as 2.7.0",
+        "zendframework/zend-filter": "^2.6",
+        "zendframework/zend-i18n": "^2.5",
+        "zendframework/zend-json": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"

--- a/test/ProcessorTest.php
+++ b/test/ProcessorTest.php
@@ -407,7 +407,9 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslator()
     {
-        $this->markTestIncomplete('Re-activate this test after zend-i18n is updated to zend-servicemanager v3');
+        if (! class_exists(ExtensionNotLoadedException::class)) {
+            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
+        }
 
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
@@ -428,7 +430,9 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorWithoutIntl()
     {
-        $this->markTestIncomplete('Re-activate this test after zend-i18n is updated to zend-servicemanager v3');
+        if (! class_exists(ExtensionNotLoadedException::class)) {
+            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
+        }
 
         if (extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl enabled');
@@ -449,7 +453,9 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorReadOnly()
     {
-        $this->markTestIncomplete('Re-activate this test after zend-i18n is updated to zend-servicemanager v3');
+        if (! class_exists(ExtensionNotLoadedException::class)) {
+            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
+        }
 
         $config     = new Config($this->translatorData, false);
         $translator = new Translator();
@@ -464,7 +470,9 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorSingleValue()
     {
-        $this->markTestIncomplete('Re-activate this test after zend-i18n is updated to zend-servicemanager v3');
+        if (! class_exists(ExtensionNotLoadedException::class)) {
+            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
+        }
 
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
@@ -479,7 +487,9 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorSingleValueWithoutIntl()
     {
-        $this->markTestIncomplete('Re-activate this test after zend-i18n is updated to zend-servicemanager v3');
+        if (! class_exists(ExtensionNotLoadedException::class)) {
+            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
+        }
 
         if (extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl enabled');


### PR DESCRIPTION
- Updated zend-stdlib to `^2.7 || ^3.0`
- Updated zend-filter to `^2.6`
- Updated zend-json to `^2.6.1`
- Set zend-i18n to `^2.5`, and:
  - travis removes the dependency when testing zend-servicemanager v3
  - `Zend\Config\ProcessorTest` skips i18n-enabled tests when zend-i18n classes are not present

This should allow us to release a stable 2.6.0 version immediately, against which other refactors can pin.