### PR TITLE
Re-enable i18n tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update "zendframework/zend-i18n" ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "zendframework/zend-filter": "^2.6",
-        "zendframework/zend-i18n": "^2.5",
+        "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-json": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "fabpot/php-cs-fixer": "1.7.*",

--- a/test/ProcessorTest.php
+++ b/test/ProcessorTest.php
@@ -407,10 +407,6 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslator()
     {
-        if (! class_exists(ExtensionNotLoadedException::class)) {
-            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -430,10 +426,6 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorWithoutIntl()
     {
-        if (! class_exists(ExtensionNotLoadedException::class)) {
-            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
-        }
-
         if (extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl enabled');
         }
@@ -453,10 +445,6 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorReadOnly()
     {
-        if (! class_exists(ExtensionNotLoadedException::class)) {
-            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
-        }
-
         $config     = new Config($this->translatorData, false);
         $translator = new Translator();
         $processor  = new TranslatorProcessor($translator);
@@ -470,10 +458,6 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorSingleValue()
     {
-        if (! class_exists(ExtensionNotLoadedException::class)) {
-            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
-        }
-
         if (!extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl not enabled');
         }
@@ -487,10 +471,6 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorSingleValueWithoutIntl()
     {
-        if (! class_exists(ExtensionNotLoadedException::class)) {
-            $this->markTestSkipped(sprintf('%s skipped to allow testing against zend-servicemanager v3', __FUNCTION__));
-        }
-
         if (extension_loaded('intl')) {
             $this->markTestSkipped('ext/intl enabled');
         }


### PR DESCRIPTION
Now that zend-i18n has a stable, forwards-compatible version, we can re-enable tests against it on Travis.