### PR TITLE
Removed bool as return Value for fromString

### DIFF
--- a/src/Reader/Xml.php
+++ b/src/Reader/Xml.php
@@ -85,7 +85,7 @@ class Xml implements ReaderInterface
      *
      * @see    ReaderInterface::fromString()
      * @param  string $string
-     * @return array|bool
+     * @return array
      * @throws Exception\RuntimeException
      */
     public function fromString($string)


### PR DESCRIPTION
The PHPDoc for Reader\Xml::fromString states a Boolean could be returned. But there is no way, a Boolean could be returned. Also there don't exists a Unit Test for this case.
So i changed the PHPDoc and removed the Boolean as return Type
