### PR TITLE
Fix array syntax

### DIFF
--- a/doc/book/intro.md
+++ b/doc/book/intro.md
@@ -57,7 +57,7 @@ The following code illustrates how to use PHP configuration files:
 // config.php
 return [
     'webhost'  => 'www.example.com',
-    'database' => array(
+    'database' => [
         'adapter' => 'pdo_mysql',
         'params'  => [
             'host'     => 'db.example.com',


### PR DESCRIPTION
syntax error : starting with 'array(' but finishing with ']'
