### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - secure: "jx8uWYQ+9AizRVN4c+zWAT0plgTNcpYIJmvJ36dr0bZuGBb3PU4zd8vhqsNcd+q4f+pdeCM5u6gPTq8oUsmziQk4Ie9OvHMwdVIA1HhOvnjo4DvC2knqFeU97oguUS+lpl0eq5abGZMf+NrhzpIBjlAVSFGNYkAmCIKBRUjfFxigam65KKJ2gk1UUwPU6ozJ1z9WXeNZ5vDgXtdnMOur6ijWZ4jL81BP7h/daF/U64K8ZrajrL4qhwD58n56pHIXFmODUgwOnZofGWQ8iAmtpzR1cP0/KA3fUqpRNha6Hd9BScZizjoE/qcQgu3JuCqpqinLXFZbInhUE5O3qU5lHcokgnnOzotudI7ytbe+XTy+UH5p7RaW3l1LgNmoCc6/VxT5b/fXfxNp3V/dXZhu4br73bixA/oV8Fnatti4jRm+za5QdwGtwCp59+eWkz/AUhGXR/vc4Hq9l0EXUS1zMBBvBXrnYMQFp1GYErY6+HIH8rAruueoAxy3yEigL9BnIiA06j5teuf0iCdNtJystbCrCiGRXa/RAnzJoZxa+Kp+A0O+Gbgrz9LnQ0uYRCMxdBXMZRlbqHgi0usj/mfGtr8rnEB2NRNvMo2uYbJv6QJo71Ql5BgRD3OdKUzjj5N3+to90fa+PT6JrVy+FW+I4Qc0VAmJnJ3ggxW0puo//eI="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.5
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
