### PR TITLE
Add consistency to method chaining DocBlocks

### DIFF
--- a/src/AbstractConfigFactory.php
+++ b/src/AbstractConfigFactory.php
@@ -116,7 +116,7 @@ class AbstractConfigFactory implements AbstractFactoryInterface
 
     /**
      * @param string $pattern
-     * @return self
+     * @return AbstractConfigFactory Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function addPattern($pattern)
@@ -133,7 +133,7 @@ class AbstractConfigFactory implements AbstractFactoryInterface
 
     /**
      * @param array|Traversable $patterns
-     * @return self
+     * @return AbstractConfigFactory Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function addPatterns($patterns)
@@ -155,7 +155,7 @@ class AbstractConfigFactory implements AbstractFactoryInterface
 
     /**
      * @param array|Traversable $patterns
-     * @return self
+     * @return AbstractConfigFactory Provides a fluent interface
      * @throws \InvalidArgumentException
      */
     public function setPatterns($patterns)

--- a/src/Config.php
+++ b/src/Config.php
@@ -324,7 +324,7 @@ class Config implements Countable, Iterator, ArrayAccess
      * - Items in $merge with STRING keys will overwrite current values.
      *
      * @param  Config $merge
-     * @return Config
+     * @return Config Provides a fluent interface
      */
     public function merge(Config $merge)
     {

--- a/src/Processor/Constant.php
+++ b/src/Processor/Constant.php
@@ -48,7 +48,7 @@ class Constant extends Token implements ProcessorInterface
      * Should we use only user-defined constants?
      *
      * @param  bool $userOnly
-     * @return Constant
+     * @return Constant Provides a fluent interface
      */
     public function setUserOnly($userOnly)
     {

--- a/src/Processor/Filter.php
+++ b/src/Processor/Filter.php
@@ -32,7 +32,7 @@ class Filter implements ProcessorInterface
 
     /**
      * @param  ZendFilter $filter
-     * @return Filter
+     * @return Filter Provides a fluent interface
      */
     public function setFilter(ZendFilter $filter)
     {

--- a/src/Processor/Token.php
+++ b/src/Processor/Token.php
@@ -62,7 +62,7 @@ class Token implements ProcessorInterface
 
     /**
      * @param  string $prefix
-     * @return Token
+     * @return Token Provides a fluent interface
      */
     public function setPrefix($prefix)
     {
@@ -82,7 +82,7 @@ class Token implements ProcessorInterface
 
     /**
      * @param  string $suffix
-     * @return Token
+     * @return Token Provides a fluent interface
      */
     public function setSuffix($suffix)
     {
@@ -106,7 +106,7 @@ class Token implements ProcessorInterface
      *
      * @param  array|Config|Traversable  $tokens  Associative array of TOKEN => value
      *                                            to replace it with
-     * @return Token
+     * @return Token Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setTokens($tokens)
@@ -145,7 +145,7 @@ class Token implements ProcessorInterface
      *
      * @param  string $token
      * @param  mixed $value
-     * @return Token
+     * @return Token Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function addToken($token, $value)

--- a/src/Processor/Translator.php
+++ b/src/Processor/Translator.php
@@ -47,7 +47,7 @@ class Translator implements ProcessorInterface
 
     /**
      * @param  ZendTranslator $translator
-     * @return Translator
+     * @return Translator Provides a fluent interface
      */
     public function setTranslator(ZendTranslator $translator)
     {
@@ -65,7 +65,7 @@ class Translator implements ProcessorInterface
 
     /**
      * @param  string|null $locale
-     * @return Translator
+     * @return Translator Provides a fluent interface
      */
     public function setLocale($locale)
     {
@@ -83,7 +83,7 @@ class Translator implements ProcessorInterface
 
     /**
      * @param  string $textDomain
-     * @return Translator
+     * @return Translator Provides a fluent interface
      */
     public function setTextDomain($textDomain)
     {

--- a/src/Reader/Ini.php
+++ b/src/Reader/Ini.php
@@ -34,7 +34,7 @@ class Ini implements ReaderInterface
      * Set nest separator.
      *
      * @param  string $separator
-     * @return self
+     * @return Ini Provides a fluent interface
      */
     public function setNestSeparator($separator)
     {

--- a/src/Reader/Yaml.php
+++ b/src/Reader/Yaml.php
@@ -50,7 +50,7 @@ class Yaml implements ReaderInterface
      * Set callback for decoding YAML
      *
      * @param  string|callable $yamlDecoder the decoder to set
-     * @return Yaml
+     * @return Yaml Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function setYamlDecoder($yamlDecoder)

--- a/src/Writer/Ini.php
+++ b/src/Writer/Ini.php
@@ -32,7 +32,7 @@ class Ini extends AbstractWriter
      * Set nest separator.
      *
      * @param  string $separator
-     * @return self
+     * @return Ini Provides a fluent interface
      */
     public function setNestSeparator($separator)
     {
@@ -57,7 +57,7 @@ class Ini extends AbstractWriter
      * into the global namespace of the INI file.
      *
      * @param  bool $withoutSections
-     * @return Ini
+     * @return Ini Provides a fluent interface
      */
     public function setRenderWithoutSectionsFlags($withoutSections)
     {

--- a/src/Writer/PhpArray.php
+++ b/src/Writer/PhpArray.php
@@ -50,7 +50,7 @@ class PhpArray extends AbstractWriter
      * Sets whether or not to use the PHP 5.4+ "[]" array syntax.
      *
      * @param  bool $value
-     * @return self
+     * @return PhpArray Provides a fluent interface
      */
     public function setUseBracketArraySyntax($value)
     {
@@ -62,7 +62,7 @@ class PhpArray extends AbstractWriter
      * Sets whether or not to render resolvable FQN strings as scalars, using PHP 5.5+ class-keyword
      *
      * @param boolean $value
-     * @return self
+     * @return PhpArray Provides a fluent interface
      */
     public function setUseClassNameScalars($value)
     {

--- a/src/Writer/Yaml.php
+++ b/src/Writer/Yaml.php
@@ -50,7 +50,7 @@ class Yaml extends AbstractWriter
      * Set callback for decoding YAML
      *
      * @param  callable $yamlEncoder the decoder to set
-     * @return Yaml
+     * @return Yaml Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setYamlEncoder($yamlEncoder)


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
