### PR TITLE
Use `@return self` for fluent interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-json": "^2.6.1",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "phpunit/PHPUnit": "^5.7 || ^6.0",
+        "phpunit/phpunit": "^5.7 || ^6.0",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d63fc04c0b53409d569fef0256fd8985",
-    "content-hash": "40d8f5791b571bd3b86e9b9c4fc161b0",
+    "content-hash": "24892bd677512c9e4ac8d7501256a956",
     "packages": [
         {
             "name": "zendframework/zend-stdlib",
@@ -50,7 +49,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-09-13 14:38:50"
+            "time": "2016-09-13T14:38:50+00:00"
         }
     ],
     "packages-dev": [
@@ -83,7 +82,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14 19:40:03"
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -137,7 +136,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -179,7 +178,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26 22:05:40"
+            "time": "2017-01-26T22:05:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -233,7 +232,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -278,7 +277,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -325,7 +324,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -388,7 +387,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -450,7 +449,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-02 10:35:41"
+            "time": "2017-02-02T10:35:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -497,7 +496,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -538,7 +537,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -582,7 +581,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -631,7 +630,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -713,7 +712,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-08 05:57:26"
+            "time": "2017-02-08T05:57:26+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -772,7 +771,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-02-02 10:36:38"
+            "time": "2017-02-02T10:36:38+00:00"
         },
         {
             "name": "psr/container",
@@ -821,7 +820,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -866,7 +865,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2016-02-13T06:45:14+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -930,7 +929,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -982,7 +981,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1032,7 +1031,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26 07:53:53"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1099,7 +1098,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19 08:54:04"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1150,7 +1149,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1196,7 +1195,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-11-19 07:35:10"
+            "time": "2016-11-19T07:35:10+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1249,7 +1248,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19 07:33:16"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1291,7 +1290,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1334,7 +1333,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1412,7 +1411,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-02-02 03:30:00"
+            "time": "2017-02-02T03:30:00+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1462,7 +1461,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -1491,7 +1490,7 @@
                 "Coding Standard",
                 "zf"
             ],
-            "time": "2016-11-09 21:30:43"
+            "time": "2016-11-09T21:30:43+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -1551,7 +1550,7 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2016-04-18 18:32:43"
+            "time": "2016-04-18T18:32:43+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -1618,7 +1617,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2016-06-07 21:08:30"
+            "time": "2016-06-07T21:08:30+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -1673,7 +1672,7 @@
                 "json",
                 "zf2"
             ],
-            "time": "2016-02-04 21:20:26"
+            "time": "2016-02-04T21:20:26+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -1734,7 +1733,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2017-02-15 15:29:48"
+            "time": "2017-02-15T15:29:48+00:00"
         }
     ],
     "aliases": [],

--- a/src/Config.php
+++ b/src/Config.php
@@ -324,7 +324,7 @@ class Config implements Countable, Iterator, ArrayAccess
      * - Items in $merge with STRING keys will overwrite current values.
      *
      * @param  Config $merge
-     * @return Config
+     * @return self
      */
     public function merge(Config $merge)
     {

--- a/src/Processor/Constant.php
+++ b/src/Processor/Constant.php
@@ -49,7 +49,7 @@ class Constant extends Token implements ProcessorInterface
      * Should we use only user-defined constants?
      *
      * @param  bool $userOnly
-     * @return Constant
+     * @return self
      */
     public function setUserOnly($userOnly)
     {

--- a/src/Processor/Filter.php
+++ b/src/Processor/Filter.php
@@ -32,7 +32,7 @@ class Filter implements ProcessorInterface
 
     /**
      * @param  ZendFilter $filter
-     * @return Filter
+     * @return self
      */
     public function setFilter(ZendFilter $filter)
     {

--- a/src/Processor/Token.php
+++ b/src/Processor/Token.php
@@ -47,11 +47,10 @@ class Token implements ProcessorInterface
      * Token Processor walks through a Config structure and replaces all
      * occurrences of tokens with supplied values.
      *
-     * @param  array|Config|Traversable   $tokens  Associative array of TOKEN => value
-     *                                             to replace it with
-     * @param    string $prefix
-     * @param    string $suffix
-     * @return   Token
+     * @param array|Config|Traversable $tokens Associative array of TOKEN =>
+     *     value to replace it with
+     * @param string $prefix
+     * @param string $suffix
      */
     public function __construct($tokens = [], $prefix = '', $suffix = '')
     {
@@ -62,7 +61,7 @@ class Token implements ProcessorInterface
 
     /**
      * @param  string $prefix
-     * @return Token
+     * @return self
      */
     public function setPrefix($prefix)
     {
@@ -82,7 +81,7 @@ class Token implements ProcessorInterface
 
     /**
      * @param  string $suffix
-     * @return Token
+     * @return self
      */
     public function setSuffix($suffix)
     {
@@ -104,9 +103,9 @@ class Token implements ProcessorInterface
     /**
      * Set token registry.
      *
-     * @param  array|Config|Traversable  $tokens  Associative array of TOKEN => value
-     *                                            to replace it with
-     * @return Token
+     * @param array|Config|Traversable $tokens Associative array of TOKEN =>
+     *     value to replace it with
+     * @return self
      * @throws Exception\InvalidArgumentException
      */
     public function setTokens($tokens)
@@ -143,9 +142,9 @@ class Token implements ProcessorInterface
     /**
      * Add new token.
      *
-     * @param  string $token
-     * @param  mixed $value
-     * @return Token
+     * @param string $token
+     * @param mixed $value
+     * @return self
      * @throws Exception\InvalidArgumentException
      */
     public function addToken($token, $value)
@@ -166,7 +165,7 @@ class Token implements ProcessorInterface
      *
      * @param string $token
      * @param mixed $value
-     * @return Token
+     * @return self
      */
     public function setToken($token, $value)
     {

--- a/src/Processor/Translator.php
+++ b/src/Processor/Translator.php
@@ -34,9 +34,9 @@ class Translator implements ProcessorInterface
      * Translator uses the supplied Zend\I18n\Translator\Translator to find
      * and translate language strings in config.
      *
-     * @param  ZendTranslator $translator
-     * @param  string $textDomain
-     * @param  string|null $locale
+     * @param ZendTranslator $translator
+     * @param string $textDomain
+     * @param string|null $locale
      */
     public function __construct(ZendTranslator $translator, $textDomain = 'default', $locale = null)
     {
@@ -46,8 +46,8 @@ class Translator implements ProcessorInterface
     }
 
     /**
-     * @param  ZendTranslator $translator
-     * @return Translator
+     * @param ZendTranslator $translator
+     * @return self
      */
     public function setTranslator(ZendTranslator $translator)
     {
@@ -64,8 +64,8 @@ class Translator implements ProcessorInterface
     }
 
     /**
-     * @param  string|null $locale
-     * @return Translator
+     * @param string|null $locale
+     * @return self
      */
     public function setLocale($locale)
     {
@@ -82,8 +82,8 @@ class Translator implements ProcessorInterface
     }
 
     /**
-     * @param  string $textDomain
-     * @return Translator
+     * @param string $textDomain
+     * @return self
      */
     public function setTextDomain($textDomain)
     {

--- a/src/Reader/Yaml.php
+++ b/src/Reader/Yaml.php
@@ -49,8 +49,8 @@ class Yaml implements ReaderInterface
     /**
      * Set callback for decoding YAML
      *
-     * @param  string|callable $yamlDecoder the decoder to set
-     * @return Yaml
+     * @param string|callable $yamlDecoder the decoder to set
+     * @return self
      * @throws Exception\RuntimeException
      */
     public function setYamlDecoder($yamlDecoder)

--- a/src/Writer/Ini.php
+++ b/src/Writer/Ini.php
@@ -56,8 +56,8 @@ class Ini extends AbstractWriter
      * If set to true, the INI file is rendered without sections completely
      * into the global namespace of the INI file.
      *
-     * @param  bool $withoutSections
-     * @return Ini
+     * @param bool $withoutSections
+     * @return self
      */
     public function setRenderWithoutSectionsFlags($withoutSections)
     {

--- a/src/Writer/Yaml.php
+++ b/src/Writer/Yaml.php
@@ -49,8 +49,8 @@ class Yaml extends AbstractWriter
     /**
      * Set callback for decoding YAML
      *
-     * @param  callable $yamlEncoder the decoder to set
-     * @return Yaml
+     * @param callable $yamlEncoder the decoder to set
+     * @return self
      * @throws Exception\InvalidArgumentException
      */
     public function setYamlEncoder($yamlEncoder)


### PR DESCRIPTION
Supercedes #32 by updating all fluent interface methods to use `@return self`. Also includes a number of other minor phpdoc formatting fixes.