### PR TITLE
Allow processing class constants

### DIFF
--- a/doc/book/processor.md
+++ b/doc/book/processor.md
@@ -12,6 +12,22 @@ zend-config provides the following concrete implementations:
 - `Zend\Config\Processor\Token`: find and replace specific tokens.
 - `Zend\Config\Processor\Translator`: translate configuration values in other languages using `Zend\I18n\Translator`.
 
+> ### What gets processed?
+>
+> Typically, you will process configuration _values_. However, there are use
+> cases for supplying constant and/or token _keys_; one common one is for
+> using class-based constants as keys to avoid using magic "strings":
+>
+> ```json
+> {
+>     "Acme\\Compoment::CONFIG_KEY": {}
+> }
+> ```
+>
+> As such, as of version 3.1.0, the `Constant` and `Token` processors can
+> optionally also process the keys of the `Config` instance provided to them, by
+> calling `enableKeyProcessing()` on their instances.
+
 ## Zend\\Config\\Processor\\Constant
 
 ### Using Zend\\Config\\Processor\\Constant
@@ -31,6 +47,14 @@ echo $config->foo;
 ```
 
 This example returns the output: `TEST_CONST,bar`.
+
+As of version 3.1.0, you can also tell the `Constant` processor to process keys:
+
+```php
+$processor->enableKeyProcessing();
+```
+
+When enabled, any constant values found in keys will also be replaced.
 
 ## Zend\\Config\\Processor\\Filter
 
@@ -106,6 +130,14 @@ echo $config->foo;
 ```
 
 This example returns the output: `Value is TOKEN,Value is bar`.
+
+As of version 3.1.0, you can also tell the `Constant` processor to process keys:
+
+```php
+$processor->enableKeyProcessing();
+```
+
+When enabled, any token values found in keys will also be replaced.
 
 ## Zend\\Config\\Processor\\Translator
 

--- a/src/Processor/Constant.php
+++ b/src/Processor/Constant.php
@@ -115,6 +115,10 @@ class Constant extends Token implements ProcessorInterface
             return $class;
         }
 
-        return parent::doProcess($value, $replacements);
+        // While we've matched ::class, the class does not exist, and PHP will
+        // raise an error if you try to define a constant using that notation.
+        // As such, we have something that cannot possibly be a constant, so we
+        // can safely return the value verbatim.
+        return $value;
     }
 }

--- a/src/Processor/Constant.php
+++ b/src/Processor/Constant.php
@@ -79,4 +79,42 @@ class Constant extends Token implements ProcessorInterface
     {
         return $this->tokens;
     }
+
+    /**
+     * Override processing of individual value.
+     *
+     * If the value is a string and evaluates to a class constant, returns
+     * the class constant value; otherwise, delegates to the parent.
+     *
+     * @param mixed $value
+     * @param array $replacements
+     * @return mixed
+     */
+    protected function doProcess($value, array $replacements)
+    {
+        if (! is_string($value)) {
+            return parent::doProcess($value, $replacements);
+        }
+
+        if (false === strpos($value, '::')) {
+            return parent::doProcess($value, $replacements);
+        }
+
+        // Handle class constants
+        if (defined($value)) {
+            return constant($value);
+        }
+
+        // Handle ::class notation
+        if (! preg_match('/::class$/', $value)) {
+            return parent::doProcess($value, $replacements);
+        }
+
+        $class = substr($value, 0, strlen($value) - 7);
+        if (class_exists($class)) {
+            return $class;
+        }
+
+        return parent::doProcess($value, $replacements);
+    }
 }

--- a/src/Processor/Constant.php
+++ b/src/Processor/Constant.php
@@ -20,17 +20,23 @@ class Constant extends Token implements ProcessorInterface
      * Constant Processor walks through a Config structure and replaces all
      * PHP constants with their respective values
      *
-     * @param bool   $userOnly              True to process only user-defined constants,
-     *                                      false to process all PHP constants
-     * @param string $prefix                Optional prefix
-     * @param string $suffix                Optional suffix
+     * @param bool $userOnly True to process only user-defined constants,
+     *     false to process all PHP constants; defaults to true.
+     * @param string $prefix Optional prefix
+     * @param string $suffix Optional suffix
+     * @param bool $enableKeyProcessing Whether or not to enable processing of
+     *     constant values in configuration keys; defaults to false.
      * @return \Zend\Config\Processor\Constant
      */
-    public function __construct($userOnly = true, $prefix = '', $suffix = '')
+    public function __construct($userOnly = true, $prefix = '', $suffix = '', $enableKeyProcessing = false)
     {
-        $this->setUserOnly($userOnly);
-        $this->setPrefix($prefix);
-        $this->setSuffix($suffix);
+        $this->setUserOnly((bool) $userOnly);
+        $this->setPrefix((string) $prefix);
+        $this->setSuffix((string) $suffix);
+
+        if (true === $enableKeyProcessing) {
+            $this->enableKeyProcessing();
+        }
 
         $this->loadConstants();
     }

--- a/src/Processor/Constant.php
+++ b/src/Processor/Constant.php
@@ -106,7 +106,7 @@ class Constant extends Token implements ProcessorInterface
         }
 
         // Handle ::class notation
-        if (! preg_match('/::class$/', $value)) {
+        if (! preg_match('/::class$/i', $value)) {
             return parent::doProcess($value, $replacements);
         }
 

--- a/src/Processor/Token.php
+++ b/src/Processor/Token.php
@@ -239,6 +239,7 @@ class Token implements ProcessorInterface
             }
 
             foreach ($value as $key => $val) {
+                $key = $this->doProcess($key, $replacements);
                 $value->$key = $this->doProcess($val, $replacements);
             }
 

--- a/src/Processor/Token.php
+++ b/src/Processor/Token.php
@@ -56,12 +56,17 @@ class Token implements ProcessorInterface
      *     value to replace it with
      * @param string $prefix
      * @param string $suffix
+     * @param bool $enableKeyProcessing Whether or not to enable processing of
+     *     token values in configuration keys; defaults to false.
      */
-    public function __construct($tokens = [], $prefix = '', $suffix = '')
+    public function __construct($tokens = [], $prefix = '', $suffix = '', $enableKeyProcessing = false)
     {
         $this->setTokens($tokens);
-        $this->setPrefix($prefix);
-        $this->setSuffix($suffix);
+        $this->setPrefix((string) $prefix);
+        $this->setSuffix((string) $suffix);
+        if (true === $enableKeyProcessing) {
+            $this->enableKeyProcessing();
+        }
     }
 
     /**

--- a/src/Processor/Token.php
+++ b/src/Processor/Token.php
@@ -21,6 +21,13 @@ class Token implements ProcessorInterface
     protected $prefix = '';
 
     /**
+     * Whether or not to process keys as well as values.
+     *
+     * @var bool
+     */
+    protected $processKeys = false;
+
+    /**
      * Token suffix.
      *
      * @var string
@@ -171,6 +178,16 @@ class Token implements ProcessorInterface
     }
 
     /**
+     * Enable processing keys as well as values.
+     *
+     * @return void
+     */
+    public function enableKeyProcessing()
+    {
+        $this->processKeys = true;
+    }
+
+    /**
      * Build replacement map
      *
      * @return array
@@ -239,8 +256,13 @@ class Token implements ProcessorInterface
             }
 
             foreach ($value as $key => $val) {
-                $key = $this->doProcess($key, $replacements);
-                $value->$key = $this->doProcess($val, $replacements);
+                $newKey = $this->processKeys ? $this->doProcess($key, $replacements) : $key;
+                $value->$newKey = $this->doProcess($val, $replacements);
+
+                // If the processed key differs from the original, remove the original
+                if ($newKey !== $key) {
+                    unset($value->$key);
+                }
             }
 
             return $value;

--- a/src/Processor/Token.php
+++ b/src/Processor/Token.php
@@ -231,7 +231,7 @@ class Token implements ProcessorInterface
      *
      * @throws Exception\InvalidArgumentException if the provided value is a read-only {@see Config}
      */
-    private function doProcess($value, array $replacements)
+    protected function doProcess($value, array $replacements)
     {
         if ($value instanceof Config) {
             if ($value->isReadOnly()) {

--- a/test/Processor/ConstantTest.php
+++ b/test/Processor/ConstantTest.php
@@ -80,4 +80,16 @@ class ConstantTest extends TestCase
         $this->assertEquals('value', $config->get($constantValue));
         $this->assertNotEquals('value', $config->get($constantString));
     }
+
+    public function testKeyProcessingDisabledByDefault()
+    {
+        $processor = new ConstantProcessor();
+        $this->assertAttributeSame(false, 'processKeys', $processor);
+    }
+
+    public function testCanEnableKeyProcessingViaConstructorArgument()
+    {
+        $processor = new ConstantProcessor(true, '', '', true);
+        $this->assertAttributeSame(true, 'processKeys', $processor);
+    }
 }

--- a/test/Processor/ConstantTest.php
+++ b/test/Processor/ConstantTest.php
@@ -40,4 +40,46 @@ class ConstantTest extends TestCase
 
         $this->assertEquals(self::class, $config->get('test'));
     }
+
+    public function testCanProcessConstantValuesInKeys()
+    {
+        if (! defined('ZEND_CONFIG_PROCESSOR_CONSTANT_TEST')) {
+            define('ZEND_CONFIG_PROCESSOR_CONSTANT_TEST', 'test-key');
+        }
+
+        $config = new Config([
+            'ZEND_CONFIG_PROCESSOR_CONSTANT_TEST' => 'value',
+        ], true);
+
+        $processor = new ConstantProcessor();
+        $processor->process($config);
+
+        $this->assertEquals('value', $config->get(ZEND_CONFIG_PROCESSOR_CONSTANT_TEST));
+    }
+
+    public function testCanProcessClassConstantValuesInKeys()
+    {
+        $key = __CLASS__ . '::CONFIG_TEST';
+        $config = new Config([
+            $key => 'value',
+        ], true);
+
+        $processor = new ConstantProcessor();
+        $processor->process($config);
+
+        $this->assertEquals('value', $config->get(self::CONFIG_TEST));
+    }
+
+    public function testCanProcessPseudoClassConstantValuesInKeys()
+    {
+        $key = __CLASS__ . '::class';
+        $config = new Config([
+            $key => 'value',
+        ], true);
+
+        $processor = new ConstantProcessor();
+        $processor->process($config);
+
+        $this->assertEquals('value', $config->get(self::class));
+    }
 }

--- a/test/Processor/ConstantTest.php
+++ b/test/Processor/ConstantTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Config\Processor;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Config\Config;
+use Zend\Config\Processor\Constant as ConstantProcessor;
+
+class ConstantTest extends TestCase
+{
+    const CONFIG_TEST = 'config';
+
+    public function testCanResolveClassConstants()
+    {
+        $key = __CLASS__ . '::CONFIG_TEST';
+        $config = new Config([
+            'test' => __CLASS__ . '::CONFIG_TEST',
+        ], true);
+
+        $processor = new ConstantProcessor();
+        $processor->process($config);
+
+        $this->assertEquals(self::CONFIG_TEST, $config->get('test'));
+    }
+
+    public function testCanResolveClassPseudoConstant()
+    {
+        $key = __CLASS__ . '::CONFIG_TEST';
+        $config = new Config([
+            'test' => __CLASS__ . '::class',
+        ], true);
+
+        $processor = new ConstantProcessor();
+        $processor->process($config);
+
+        $this->assertEquals(self::class, $config->get('test'));
+    }
+}

--- a/test/Processor/TokenTest.php
+++ b/test/Processor/TokenTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Config\Processor;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Config\Processor\Token as TokenProcessor;
+
+/**
+ * Majority of tests are in ZendTest\Config\ProcessorTest; this class contains
+ * tests covering new functionality and/or specific bugs.
+ */
+class TokenTest extends TestCase
+{
+    public function testKeyProcessingDisabledByDefault()
+    {
+        $processor = new TokenProcessor();
+        $this->assertAttributeSame(false, 'processKeys', $processor);
+    }
+
+    public function testCanEnableKeyProcessingViaConstructorArgument()
+    {
+        $processor = new TokenProcessor([], '', '', true);
+        $this->assertAttributeSame(true, 'processKeys', $processor);
+    }
+}


### PR DESCRIPTION
This patch updates the `Constant` processor to allow processing class constants, including the `::class` pseudo-constant; additionally, it ensures that both the `Token` and `Constant` processors can apply to `Config` *keys* as well as the values by calling their `enableKeyProcessing()` methods.

To allow this to work, I've changed the visibility of `Token::doProcess()` from `private` to `protected`, to allow overriding the method within the `Constant` class. I've also added the new test case `ZendTest\Config\Processor\Constant` to cover the behavior.

Essentially, this allows the following to work (assuming the provided classes and constants exist):

```json
{
    "Acme\\Component::CONFIG_KEY": {
        "host": "Acme\\Component::CONFIG_HOST",
        "dependencies": {
	    "Acme\\Foo::class": "Acme\\FooFactory::class",
        }
    }
}
```

Via:

```php
$config = new Config(Factory::fromFile('config.json'), true);
$processor = new Processor\Constant();
$processor->enableKeyProcessing();
$processor->process($config);
```