### PR TITLE
Adds ability to specify delimiter for key/value pairs

### DIFF
--- a/src/Reader/JavaProperties.php
+++ b/src/Reader/JavaProperties.php
@@ -14,12 +14,36 @@ use Zend\Config\Exception;
  */
 class JavaProperties implements ReaderInterface
 {
+    const DELIMITER_DEFAULT = ':';
+
     /**
      * Directory of the Java-style properties file
      *
      * @var string
      */
     protected $directory;
+
+    /**
+     * Delimiter for key/value pairs.
+     */
+    private $delimiter;
+
+    /**
+     * @param string $delimiter Delimiter to use for key/value pairs; defaults
+     *     to self::DELIMITER_DEFAULT (':')
+     * @throws Exception\InvalidArgumentException for invalid $delimiter values.
+     */
+    public function __construct($delimiter = self::DELIMITER_DEFAULT)
+    {
+        if (! is_string($delimiter) || '' === $delimiter) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid delimiter of type "%s"; must be a non-empty string',
+                is_object($delimiter) ? get_class($delimiter) : gettype($delimiter)
+            ));
+        }
+
+        $this->delimiter = $delimiter;
+    }
 
     /**
      * fromFile(): defined by Reader interface.
@@ -99,6 +123,8 @@ class JavaProperties implements ReaderInterface
      */
     protected function parse($string)
     {
+        $delimiter = $this->delimiter;
+        $delimLength = strlen($delimiter);
         $result = [];
         $lines = explode("\n", $string);
         $key = "";
@@ -113,8 +139,8 @@ class JavaProperties implements ReaderInterface
 
             // Add a new key-value pair or append value to a previous pair
             if (! $isWaitingOtherLine) {
-                $key = substr($line, 0, strpos($line, ':'));
-                $value = substr($line, strpos($line, ':') + 1, strlen($line));
+                $key = substr($line, 0, strpos($line, $delimiter));
+                $value = substr($line, strpos($line, $delimiter) + $delimLength, strlen($line));
             } else {
                 $value .= $line;
             }

--- a/test/Reader/JavaPropertiesTest.php
+++ b/test/Reader/JavaPropertiesTest.php
@@ -76,4 +76,41 @@ ASSET;
         $this->expectExceptionMessage($expectedErrorMessage);
         $arrayJavaPropterties = $this->reader->fromString($JavaProperties);
     }
+
+    public function testAllowsSpecifyingAlternateKeyValueDelimiter()
+    {
+        $reader = new JavaProperties('=');
+
+        $arrayJavaProperties = $reader->fromFile($this->getTestAssetPath('alternate-delimiter'));
+
+        $this->assertNotEmpty($arrayJavaProperties);
+        $this->assertEquals($arrayJavaProperties['single.line'], 'test');
+        $this->assertEquals($arrayJavaProperties['multiple'], 'line test');
+    }
+
+    public function invalidDelimiters()
+    {
+        return [
+            'null'         => [null],
+            'true'         => [true],
+            'false'        => [false],
+            'zero'         => [0],
+            'int'          => [1],
+            'zero-float'   => [0.0],
+            'float'        => [1.1],
+            'empty-string' => [''],
+            'array'        => [[':']],
+            'object'       => [(object) ['delimiter' => ':']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidDelimiters
+     * @param mixed $delimiter
+     */
+    public function testInvalidDelimiterValuesResultInExceptions($delimiter)
+    {
+        $this->expectException(Exception\InvalidArgumentException::class);
+        new JavaProperties($delimiter);
+    }
 }

--- a/test/Reader/TestAssets/JavaProperties/alternate-delimiter.properties
+++ b/test/Reader/TestAssets/JavaProperties/alternate-delimiter.properties
@@ -1,0 +1,3 @@
+single.line=test
+multiple=line \
+test


### PR DESCRIPTION
Per #44, this patch adds the ability to specify via the constructor the key/value pair delimiter to use when parsing a JavaProperties file. By default, this will be `:`, but it can be any non-empty string.