### PR TITLE
Adds JavaProperties reader option to trim whitespace from keys and values

### DIFF
--- a/test/Reader/JavaPropertiesTest.php
+++ b/test/Reader/JavaPropertiesTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-config for the canonical source repository
- * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
  */
 
@@ -112,5 +112,15 @@ ASSET;
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         new JavaProperties($delimiter);
+    }
+
+    public function testProvidesOptionToTrimWhitespaceFromKeysAndValues()
+    {
+        $reader = new JavaProperties(JavaProperties::DELIMITER_DEFAULT, JavaProperties::WHITESPACE_TRIM);
+        $arrayJavaProperties = $reader->fromFile($this->getTestAssetPath('key-value-whitespace'));
+
+        $this->assertNotEmpty($arrayJavaProperties);
+        $this->assertEquals($arrayJavaProperties['single.line'], 'test');
+        $this->assertEquals($arrayJavaProperties['multiple'], 'line test');
     }
 }

--- a/test/Reader/TestAssets/JavaProperties/key-value-whitespace.properties
+++ b/test/Reader/TestAssets/JavaProperties/key-value-whitespace.properties
@@ -1,0 +1,3 @@
+single.line : test  
+ multiple : line \
+test   


### PR DESCRIPTION
Per #44, this patch adds a constructor option allowing users to require that keys and values are trimmed during parsing. This allows the delimiter to be surrounded by whitespace, and also allows for indentation:

```php
$reader = new JavaProperties(
    JavaProperties::DELIMITER_DEFAULT, // or ':'
    JavaProperties::WHITESPACE_TRIM    // or true
);
```