### PR TITLE
Adds JavaProperties writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#47](https://github.com/zendframework/zend-config/pull/47) adds `Zend\Config\Writer\JavaProperties`, a complement to
+  `Zend\Config\Reader\JavaProperties`, for writing JavaProperties files from configuration. The writer supports
+  specifying an alternate key/value delimiter (the default is ":") via the constructor.
+
 - [#46](https://github.com/zendframework/zend-config/pull/46) adds a constructor option to the JavaProperties reader to allow
   users to indicate keys and values from the configuration should be trimmed of whitespace:
 
@@ -20,6 +24,10 @@ All notable changes to this project will be documented in this file, in reverse 
   the JavaProperties config reader via the constructor: `$reader = new JavaProperties("=");`.
 
 - [#42](https://github.com/zendframework/zend-config/pull/42) adds support for PHP 7.1 and 7.2.
+
+### Changed
+
+- Nothing.
 
 ### Deprecated
 

--- a/docs/book/writer.md
+++ b/docs/book/writer.md
@@ -5,12 +5,13 @@
 is itself only an interface that defining the methods `toFile()` and
 `toString()`.
 
-We have five writers implementing the interface:
+We have six writers implementing the interface:
 
 - `Zend\Config\Writer\Ini`
-- `Zend\Config\Writer\Xml`
-- `Zend\Config\Writer\PhpArray`
+- `Zend\Config\Writer\JavaProperties`
 - `Zend\Config\Writer\Json`
+- `Zend\Config\Writer\PhpArray`
+- `Zend\Config\Writer\Xml`
 - `Zend\Config\Writer\Yaml`
 
 ## Zend\\Config\\Writer\\Ini
@@ -64,6 +65,67 @@ database.params.dbname = "dbproduction"
 ```
 
 You can use the method `toFile()` to store the INI data to a file instead.
+
+## Zend\\Config\\Writer\\JavaProperties
+
+- Since 3.2.0
+
+The JavaProperties writer can only write single-dimensional configuration (i.e.,
+key/value pairs); this is a limitation of the JavaProperties format.
+
+`Zend\Config\Writer\JavaProperties` has a single, optional constructor
+parameter, `delimiter`, which defines with which character the key/value pairs
+are separated. The default is a single colon (`:`), such as is accepted by
+`Zend\Config\Reader\JavaProperties` by default.
+
+### Using Zend\\Config\\Writer\\JavaProperties
+
+Consider the following code, creating configuration:
+
+```php
+// Create the config object
+$config = new Zend\Config\Config([], true);
+
+$config->webhost             = 'www.example.com'; // use object notation
+$config['database.host']     = 'localhost';       // or array notation, for complex key names
+$config['database.username'] = 'production';
+$config['database.password'] = 'secret';
+$config['database.dbname']   = 'dbproduction';
+
+$writer = new Zend\Config\Writer\JavaProperties();
+echo $writer->toString($config);
+```
+
+The result of this code is the following JavaProperties string:
+
+```properties
+webhost:www.example.com
+database.host:localhost
+database.username:production
+database.password:secret
+database.dbname:dbproduction
+```
+
+You can use the method `toFile()` to store the JavaProperties data to a file instead.
+
+### Using an alternate delimiter
+
+If you want to use an alternate delimiter, such as `=`, pass it to the
+constructor:
+
+```php
+$writer = new Zend\Config\Writer\JavaProperties('=');
+```
+
+Using the above configuration, we would now receive:
+
+```properties
+webhost=www.example.com
+database.host=localhost
+database.username=production
+database.password=secret
+database.dbname=dbproduction
+```
 
 ## Zend\\Config\\Writer\\Xml
 

--- a/src/Exception/UnprocessableConfigException.php
+++ b/src/Exception/UnprocessableConfigException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Config\Exception;
+
+class UnprocessableConfigException extends RuntimeException
+{
+}

--- a/src/StandaloneWriterPluginManager.php
+++ b/src/StandaloneWriterPluginManager.php
@@ -12,12 +12,13 @@ use Psr\Container\ContainerInterface;
 class StandaloneWriterPluginManager implements ContainerInterface
 {
     private $knownPlugins = [
-        'ini'      => Writer\Ini::class,
-        'json'     => Writer\Json::class,
-        'php'      => Writer\PhpArray::class,
-        'phparray' => Writer\PhpArray::class,
-        'xml'      => Writer\Xml::class,
-        'yaml'     => Writer\Yaml::class,
+        'ini'            => Writer\Ini::class,
+        'javaproperties' => Writer\JavaProperties::class,
+        'json'           => Writer\Json::class,
+        'php'            => Writer\PhpArray::class,
+        'phparray'       => Writer\PhpArray::class,
+        'xml'            => Writer\Xml::class,
+        'yaml'           => Writer\Yaml::class,
     ];
 
     /**

--- a/src/Writer/JavaProperties.php
+++ b/src/Writer/JavaProperties.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Config\Writer;
+
+use Zend\Config\Exception;
+
+class JavaProperties extends AbstractWriter
+{
+    const DELIMITER_DEFAULT = ':';
+
+    /**
+     * Delimiter for key/value pairs.
+     */
+    private $delimiter;
+
+    /**
+     * @param string $delimiter Delimiter to use for key/value pairs; defaults
+     *     to self::DELIMITER_DEFAULT (':')
+     * @throws Exception\InvalidArgumentException for invalid $delimiter values.
+     */
+    public function __construct($delimiter = self::DELIMITER_DEFAULT)
+    {
+        if (! is_string($delimiter) || '' === $delimiter) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid delimiter of type "%s"; must be a non-empty string',
+                is_object($delimiter) ? get_class($delimiter) : gettype($delimiter)
+            ));
+        }
+
+        $this->delimiter = $delimiter;
+    }
+
+    /**
+     * processConfig(): defined by AbstractWriter.
+     *
+     * @param  array $config
+     * @return string
+     * @throws Exception\UnprocessableConfigException for non-scalar values in
+     *     the $config array.
+     */
+    public function processConfig(array $config)
+    {
+        $string = '';
+
+        foreach ($config as $key => $value) {
+            if (! is_scalar($value)) {
+                throw new Exception\UnprocessableConfigException(sprintf(
+                    '%s configuration writer can only process scalar values; received "%s" for key "%s"',
+                    __CLASS__,
+                    is_object($value) ? get_class($value) : gettype($value),
+                    $key
+                ));
+            }
+
+            $value = (null === $value) ? '' : $value;
+
+            $string .= sprintf(
+                "%s%s%s\n",
+                $key,
+                $this->delimiter,
+                $value
+            );
+        }
+
+        return $string;
+    }
+}

--- a/src/WriterPluginManager.php
+++ b/src/WriterPluginManager.php
@@ -17,34 +17,39 @@ class WriterPluginManager extends AbstractPluginManager
     protected $instanceOf = Writer\AbstractWriter::class;
 
     protected $aliases = [
-        'ini'      => Writer\Ini::class,
-        'Ini'      => Writer\Ini::class,
-        'json'     => Writer\Json::class,
-        'Json'     => Writer\Json::class,
-        'php'      => Writer\PhpArray::class,
-        'phparray' => Writer\PhpArray::class,
-        'phpArray' => Writer\PhpArray::class,
-        'PhpArray' => Writer\PhpArray::class,
-        'yaml'     => Writer\Yaml::class,
-        'Yaml'     => Writer\Yaml::class,
-        'xml'      => Writer\Xml::class,
-        'Xml'      => Writer\Xml::class,
+        'ini'            => Writer\Ini::class,
+        'Ini'            => Writer\Ini::class,
+        'json'           => Writer\Json::class,
+        'Json'           => Writer\Json::class,
+        'php'            => Writer\PhpArray::class,
+        'phparray'       => Writer\PhpArray::class,
+        'phpArray'       => Writer\PhpArray::class,
+        'PhpArray'       => Writer\PhpArray::class,
+        'yaml'           => Writer\Yaml::class,
+        'Yaml'           => Writer\Yaml::class,
+        'xml'            => Writer\Xml::class,
+        'Xml'            => Writer\Xml::class,
+        'javaproperties' => Writer\JavaProperties::class,
+        'javaProperties' => Writer\JavaProperties::class,
+        'JavaProperties' => Writer\JavaProperties::class,
     ];
 
     protected $factories = [
-        Writer\Ini::class      => InvokableFactory::class,
-        Writer\Json::class     => InvokableFactory::class,
-        Writer\PhpArray::class => InvokableFactory::class,
-        Writer\Yaml::class     => InvokableFactory::class,
-        Writer\Xml::class      => InvokableFactory::class,
+        Writer\Ini::class            => InvokableFactory::class,
+        Writer\JavaProperties::class => InvokableFactory::class,
+        Writer\Json::class           => InvokableFactory::class,
+        Writer\PhpArray::class       => InvokableFactory::class,
+        Writer\Yaml::class           => InvokableFactory::class,
+        Writer\Xml::class            => InvokableFactory::class,
         // Legacy (v2) due to alias resolution; canonical form of resolved
         // alias is used to look up the factory, while the non-normalized
         // resolved alias is used as the requested name passed to the factory.
-        'zendconfigwriterini'      => InvokableFactory::class,
-        'zendconfigwriterjson'     => InvokableFactory::class,
-        'zendconfigwriterphparray' => InvokableFactory::class,
-        'zendconfigwriteryaml'     => InvokableFactory::class,
-        'zendconfigwriterxml'      => InvokableFactory::class,
+        'zendconfigwriterini'            => InvokableFactory::class,
+        'zendconfigwriterjavaproperties' => InvokableFactory::class,
+        'zendconfigwriterjson'           => InvokableFactory::class,
+        'zendconfigwriterphparray'       => InvokableFactory::class,
+        'zendconfigwriteryaml'           => InvokableFactory::class,
+        'zendconfigwriterxml'            => InvokableFactory::class,
     ];
 
     /**

--- a/test/Writer/JavaPropertiesTest.php
+++ b/test/Writer/JavaPropertiesTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Config\Writer;
+
+use Zend\Config\Config;
+use Zend\Config\Reader\JavaProperties as JavaPropertiesReader;
+use Zend\Config\Writer\JavaProperties as JavaPropertiesWriter;
+
+class JavaPropertiesTest extends AbstractWriterTestCase
+{
+    public function setUp()
+    {
+        $this->reader = new JavaPropertiesReader();
+        $this->writer = new JavaPropertiesWriter();
+    }
+
+    public function testNoSection()
+    {
+        $config = new Config(['test' => 'foo', 'test2.test3' => 'bar']);
+
+        $this->writer->toFile($this->getTestAssetFileName(), $config);
+
+        $config = $this->reader->fromFile($this->getTestAssetFileName());
+
+        $this->assertEquals('foo', $config['test']);
+        $this->assertEquals('bar', $config['test2.test3']);
+    }
+
+    public function testWriteAndRead()
+    {
+        $this->markTestSkipped('JavaProperties writer cannot handle multi-dimensional configuration');
+    }
+
+    public function testWriteAndReadOriginalFile()
+    {
+        $config = $this->reader->fromFile(__DIR__ . '/_files/allsections.properties');
+
+        $this->writer->toFile($this->getTestAssetFileName(), $config);
+
+        $config = $this->reader->fromFile($this->getTestAssetFileName());
+
+        $this->assertEquals('multi', $config['one.two.three']);
+    }
+
+    public function testWriteAndReadOriginalFileWithCustomDelimiter()
+    {
+        $config = $this->reader->fromFile(__DIR__ . '/_files/allsections.properties');
+
+        $writer = new JavaPropertiesWriter('=');
+        $writer->toFile($this->getTestAssetFileName(), $config);
+
+        $reader = new JavaPropertiesReader('=');
+        $config = $reader->fromFile($this->getTestAssetFileName());
+
+        $this->assertEquals('multi', $config['one.two.three']);
+    }
+}

--- a/test/Writer/_files/allsections.properties
+++ b/test/Writer/_files/allsections.properties
@@ -1,0 +1,7 @@
+hostname:all
+name:thisname
+db.host:127.0.0.1
+db.user:username
+db.pass:password
+db.name:live
+one.two.three:multi


### PR DESCRIPTION
Per #44, this patch provides a simple JavaProperties writer that uses the configured delimiter in order to create key{delim}value lines representing the configuration provided.

Usage:

```php
// Using default delimiter of ':':
$writer = new JavaProperties();

// Using alternate delimiter:
$writer = new JavaProperties('=');

$writer->toFile('.properties', $config);
```