### PR TITLE
Added Env processor to allows users to read the value of the getenv() function in static configuration files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 3.3.1 - 2018-06-15
+
+### Added
+
+- Added Env processor to allows users to read the value of the getenv() function in static configuration files.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.3.0 - TBD
 
 ### Added

--- a/docs/book/processor.md
+++ b/docs/book/processor.md
@@ -7,6 +7,7 @@ defining two methods: `process()` and `processValue()`.
 zend-config provides the following concrete implementations:
 
 - `Zend\Config\Processor\Constant`: manage PHP constant values.
+- `Zend\Config\Processor\Env`: manage PHP getenv() function values.
 - `Zend\Config\Processor\Filter`: filter the configuration data using `Zend\Filter`.
 - `Zend\Config\Processor\Queue`: manage a queue of operations to apply to configuration data.
 - `Zend\Config\Processor\Token`: find and replace specific tokens.
@@ -58,8 +59,38 @@ $processor = new Zend\Config\Processor\Constant(true, '', '', true);
 // Or later, via a method call:
 $processor->enableKeyProcessing();
 ```
-
 When enabled, any constant values found in keys will also be replaced.
+
+## Zend\\Config\\Processor\\Env
+
+### Using Zend\\Config\\Processor\\Env
+
+This example illustrates the basic usage of `Zend\Config\Processor\Env`:
+
+```php
+putenv('AMQP_PASSWORD=guest');
+
+use Zend\Config\Config;
+use Zend\Config\Factory;
+use Zend\Config\Processor\Env as EnvProcessor;
+
+$config = new Config([
+            'host' => '127.0.0.1',
+            'port' => 5672,
+            'username' => 'guest',
+            'password' => 'env(AMQP_PASSWORD)',
+            'vhost' => '/',
+        ], true);
+
+$processor = new EnvProcessor;
+$processor->process($config);
+$config->setReadOnly();
+
+echo $config->amqp->password;
+```
+
+This example returns the output: `guest`.
+
 
 ## Zend\\Config\\Processor\\Filter
 

--- a/src/Processor/Env.php
+++ b/src/Processor/Env.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Config\Processor;
+
+class Env extends Token implements ProcessorInterface
+{
+    /**
+     * Override processing of individual value.
+     *
+     * If the value is a string and evaluates to a getenv function, returns
+     * the getenv() method value; otherwise, delegates to the parent.
+     *
+     * @param mixed $value
+     * @param array $replacements
+     * @return mixed
+     */
+    protected function doProcess($value, array $replacements)
+    {
+        if (! is_string($value)) {
+            return parent::doProcess($value, $replacements);
+        }
+
+        if (false === strpos($value, 'env(')) {
+            return parent::doProcess($value, $replacements);
+        }
+        $value = $this->parseEnvRecursive($value);
+
+        return $value;
+    }
+
+    /**
+     * Parse env variables
+     * 
+     * @param mixed $input input
+     * @return string
+     */
+    protected function parseEnvRecursive($input)
+    {
+        $regex = '/env\((.*?)\)/';
+        if (is_array($input)) {
+            $input = getenv($input[1]);
+        }
+        return preg_replace_callback($regex, array($this, 'parseEnvRecursive'), $input);
+    }
+}

--- a/src/Processor/Env.php
+++ b/src/Processor/Env.php
@@ -35,7 +35,7 @@ class Env extends Token implements ProcessorInterface
 
     /**
      * Parse env variables
-     * 
+     *
      * @param mixed $input input
      * @return string
      */
@@ -45,6 +45,6 @@ class Env extends Token implements ProcessorInterface
         if (is_array($input)) {
             $input = getenv($input[1]);
         }
-        return preg_replace_callback($regex, array($this, 'parseEnvRecursive'), $input);
+        return preg_replace_callback($regex, [$this, 'parseEnvRecursive'], $input);
     }
 }

--- a/test/Processor/EnvTest.php
+++ b/test/Processor/EnvTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Config\Processor;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Config\Config;
+use Zend\Config\Processor\Env as EnvProcessor;
+
+class EnvTest extends TestCase
+{
+    public function getEnvProvider()
+    {
+        if (! getenv('AMQP_USERNAME')) {
+            putenv('AMQP_USERNAME=guest');
+            putenv('AMQP_PASSWORD=guest');
+        }
+
+        return [
+            'host' => '127.0.0.1',
+            'port' => 5672,
+            'username' => 'env(AMQP_USERNAME)',
+            'password' => 'env(AMQP_PASSWORD)',
+            'vhost' => '/',
+        ];
+    }
+
+    public function testCanResolveEnvValues()
+    {
+        $config = new Config($this->getEnvProvider(), true);
+
+        $processor = new EnvProcessor();
+        $processor->process($config);
+
+        $this->assertEquals('127.0.0.1', $config->get('host'));
+        $this->assertEquals(5672, $config->get('port'));
+        $this->assertEquals('guest', $config->get('username'));
+        $this->assertEquals('guest', $config->get('password'));
+        $this->assertEquals('/', $config->get('vhost'));
+    }
+}


### PR DESCRIPTION
This feature will allow getenv function to be run from static files like yaml.

### Using Zend\\Config\\Processor\\Env

This example illustrates the basic usage of `Zend\Config\Processor\Env`:

```php
putenv('AMQP_PASSWORD=guest');

use Zend\Config\Config;
use Zend\Config\Factory;
use Zend\Config\Processor\Env as EnvProcessor;

$config = new Config([
            'host' => '127.0.0.1',
            'port' => 5672,
            'username' => 'guest',
            'password' => 'env(AMQP_PASSWORD)',
            'vhost' => '/',
        ], true);

$processor = new EnvProcessor;
$processor->process($config);
$config->setReadOnly();

echo $config->amqp->password;
```

This example returns the output: `guest`.
