### PR TITLE
Fix issue #55 - Infinite loop if class is extended and array has another array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [Issue #55](https://github.com/zendframework/zend-config/issues/55) - Infinite loop if class is extended (under specific circumstances)
 
 ## 3.2.0 - 2018-04-24
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config implements Countable, Iterator, ArrayAccess
 
         foreach ($array as $key => $value) {
             if (is_array($value)) {
-                $this->data[$key] = new static($value, $this->allowModifications);
+                $this->data[$key] = new self($value, $this->allowModifications);
             } else {
                 $this->data[$key] = $value;
             }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [ ] Details in the issue #55 
  - [ ] Infinite loop
  - [ ] Using self will not cause extending class to be called

No tests are supplied because existing tests cover this change.