### PR TITLE
Subnodes has the same type as the parent node

### DIFF
--- a/docs/book/theory.md
+++ b/docs/book/theory.md
@@ -14,6 +14,22 @@ is itself an array, then the resulting object property is created as a new
 recursively, such that a hierarchy of configuration data may be created with any
 number of levels.
 
+> ### Extending `Zend\Config\Config` class
+>
+> If you decide to extend `Zend\Config\Config` class all each property (subnode)
+> becomes the same type as the parent class. For example:
+>
+> ```php
+> class ExtendedConfig extends Zend\Config\Config
+> {
+> }
+>
+> $config = new ExtendedConfig(['node' => ['key' => 'value']]);
+>
+> echo get_class($config->node);
+> // the result of above is ExtendedConfig not Zend\Config\Config!
+> ```
+
 `Zend\Config\Config` implements the [Countable](http://php.net/manual/en/class.countable.php)
 and [Iterator](http://php.net/manual/en/class.iterator.php) interfaces in order
 to facilitate simple access to configuration data. Thus, `Zend\Config\Config`

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -639,4 +639,15 @@ class ConfigTest extends TestCase
         $configA->merge($configB); // merge B onto A
         $this->assertEquals($mergeResult, $configA->toArray());
     }
+
+    public function testExtendedConfigHasSubnodesTheSameType()
+    {
+        $config = new TestAssets\ExtendedConfig([
+            'node' => [
+                'key' => 'value',
+            ],
+        ]);
+
+        $this->assertInstanceOf(TestAssets\ExtendedConfig::class, $config->node);
+    }
 }

--- a/test/TestAssets/ExtendedConfig.php
+++ b/test/TestAssets/ExtendedConfig.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Config\TestAssets;
+
+use Zend\Config\Config;
+
+class ExtendedConfig extends Config
+{
+}


### PR DESCRIPTION
In case we extend the Config class we would like to have the same type of the subnodes as the parent node.

Relates to #55 / #56 

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->
