### PR TITLE
Implemented option to process INI sections or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [#58](https://github.com/zendframework/zend-config/pull/58) adds `$processSections` to INI reader, allowing control over
-    whether sections should be parsed or not
+- [#58](https://github.com/zendframework/zend-config/pull/58) adds
+  `$processSections` to INI reader, allowing control over whether sections
+  should be parsed or not
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#58](https://github.com/zendframework/zend-config/pull/58) adds `$processSections` to INI reader, allowing control over
+    whether sections should be parsed or not
 
 ### Changed
 

--- a/docs/book/reader.md
+++ b/docs/book/reader.md
@@ -42,6 +42,17 @@ function. Please review this documentation to be aware of its specific behaviors
 > $reader->setNestSeparator('-');
 > ```
 
+> ### Process Sections
+>
+> By default, the INI reader executes `parse_ini_file()`  with the optional parameter `$process_sections` being `true`. The result is a multidimensional array, with the section names and settings included.
+>
+> To merge sections, set the parameter via `setProcessSections()` to `false` as follows.
+>
+> ```php
+> $reader = new Zend\Config\Reader\Ini();
+> $reader->setProcessSections(false);
+> ```
+
 The following example illustrates basic usage of `Zend\Config\Reader\Ini` for
 loading configuration data from an INI file. In this example, configuration data
 for both a production system and for a staging system exists.

--- a/src/Reader/Ini.php
+++ b/src/Reader/Ini.php
@@ -29,6 +29,14 @@ class Ini implements ReaderInterface
     protected $directory;
 
     /**
+     * Flag which determines whether sections are processed or not.
+     *
+     * @see https://www.php.net/parse_ini_file
+     * @var bool
+     */
+    protected $processSections = true;
+
+    /**
      * Set nest separator.
      *
      * @param  string $separator
@@ -48,6 +56,28 @@ class Ini implements ReaderInterface
     public function getNestSeparator()
     {
         return $this->nestSeparator;
+    }
+
+    /**
+     * Sets process sections
+     *
+     * @param bool $processSections
+     * @return $this
+     */
+    public function setProcessSections($processSections)
+    {
+        $this->processSections = (bool) $processSections;
+        return $this;
+    }
+
+    /**
+     * Get process sections
+     *
+     * @return bool
+     */
+    public function getProcessSections()
+    {
+        return $this->processSections;
     }
 
     /**
@@ -78,7 +108,7 @@ class Ini implements ReaderInterface
             },
             E_WARNING
         );
-        $ini = parse_ini_file($filename, true);
+        $ini = parse_ini_file($filename, $this->getProcessSections());
         restore_error_handler();
 
         return $this->process($ini);
@@ -107,7 +137,7 @@ class Ini implements ReaderInterface
             },
             E_WARNING
         );
-        $ini = parse_ini_string($string, true);
+        $ini = parse_ini_string($string, $this->getProcessSections());
         restore_error_handler();
 
         return $this->process($ini);

--- a/src/Reader/Ini.php
+++ b/src/Reader/Ini.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-config for the canonical source repository
- * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
  */
 
@@ -59,8 +59,11 @@ class Ini implements ReaderInterface
     }
 
     /**
-     * Sets process sections
+     * Marks whether sections should be processed.
+     * When sections are not processed,section names are stripped and section
+     * values are merged
      *
+     * @see https://www.php.net/parse_ini_file
      * @param bool $processSections
      * @return $this
      */
@@ -71,8 +74,11 @@ class Ini implements ReaderInterface
     }
 
     /**
-     * Get process sections
+     * Get if sections should be processed
+     * When sections are not processed,section names are stripped and section
+     * values are merged
      *
+     * @see https://www.php.net/parse_ini_file
      * @return bool
      */
     public function getProcessSections()

--- a/test/Reader/IniTest.php
+++ b/test/Reader/IniTest.php
@@ -48,9 +48,9 @@ bar[]= "foo"
 ECS;
 
         $arrayIni = $this->reader->fromString($ini);
-        $this->assertEquals($arrayIni['test'], 'foo');
-        $this->assertEquals($arrayIni['bar'][0], 'baz');
-        $this->assertEquals($arrayIni['bar'][1], 'foo');
+        $this->assertEquals('foo', $arrayIni['test']);
+        $this->assertEquals('baz', $arrayIni['bar'][0]);
+        $this->assertEquals('foo', $arrayIni['bar'][1]);
     }
 
     public function testInvalidString()
@@ -74,9 +74,9 @@ bar[]= "foo"
 ECS;
 
         $arrayIni = $this->reader->fromString($ini);
-        $this->assertEquals($arrayIni['all']['test'], 'foo');
-        $this->assertEquals($arrayIni['all']['bar'][0], 'baz');
-        $this->assertEquals($arrayIni['all']['bar'][1], 'foo');
+        $this->assertEquals('foo', $arrayIni['all']['test']);
+        $this->assertEquals('baz', $arrayIni['all']['bar'][0]);
+        $this->assertEquals('foo', $arrayIni['all']['bar'][1]);
     }
 
     public function testFromStringNested()
@@ -90,20 +90,20 @@ bla.foo.baz[] = foobaz2
 ECS;
 
         $arrayIni = $this->reader->fromString($ini);
-        $this->assertEquals($arrayIni['bla']['foo']['bar'], 'foobar');
-        $this->assertEquals($arrayIni['bla']['foobar'][0], 'foobarArray');
-        $this->assertEquals($arrayIni['bla']['foo']['baz'][0], 'foobaz1');
-        $this->assertEquals($arrayIni['bla']['foo']['baz'][1], 'foobaz2');
+        $this->assertEquals('foobar', $arrayIni['bla']['foo']['bar']);
+        $this->assertEquals('foobarArray', $arrayIni['bla']['foobar'][0]);
+        $this->assertEquals('foobaz1', $arrayIni['bla']['foo']['baz'][0]);
+        $this->assertEquals('foobaz2', $arrayIni['bla']['foo']['baz'][1]);
     }
 
     public function testFromFileParseSections()
     {
         $arrayIni = $this->reader->fromFile($this->getTestAssetPath('sections'));
 
-        $this->assertEquals($arrayIni['production']['env'], 'production');
-        $this->assertEquals($arrayIni['production']['production_key'], 'foo');
-        $this->assertEquals($arrayIni['staging : production']['env'], 'staging');
-        $this->assertEquals($arrayIni['staging : production']['staging_key'], 'bar');
+        $this->assertEquals('production', $arrayIni['production']['env']);
+        $this->assertEquals('foo', $arrayIni['production']['production_key']);
+        $this->assertEquals('staging', $arrayIni['staging : production']['env']);
+        $this->assertEquals('bar', $arrayIni['staging : production']['staging_key']);
     }
 
     public function testFromFileDontParseSections()
@@ -113,8 +113,8 @@ ECS;
 
         $arrayIni = $reader->fromFile($this->getTestAssetPath('sections'));
 
-        $this->assertEquals($arrayIni['env'], 'staging');
-        $this->assertEquals($arrayIni['production_key'], 'foo');
-        $this->assertEquals($arrayIni['staging_key'], 'bar');
+        $this->assertEquals('staging', $arrayIni['env']);
+        $this->assertEquals('foo', $arrayIni['production_key']);
+        $this->assertEquals('bar', $arrayIni['staging_key']);
     }
 }

--- a/test/Reader/IniTest.php
+++ b/test/Reader/IniTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-config for the canonical source repository
- * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-config/blob/master/LICENSE.md New BSD License
  */
 
@@ -118,6 +118,23 @@ ECS;
         $this->assertEquals('bar', $arrayIni['staging_key']);
     }
 
+    public function testFromFileIgnoresNestingInSectionNamesWhenSectionsNotProcessed()
+    {
+        $reader = $this->reader;
+        $reader->setProcessSections(false);
+
+        $arrayIni = $reader->fromFile($this->getTestAssetPath('nested-sections'));
+
+        $this->assertArrayNotHasKey('environments.production', $arrayIni);
+        $this->assertArrayNotHasKey('environments.staging', $arrayIni);
+        $this->assertArrayNotHasKey('environments', $arrayIni);
+        $this->assertArrayNotHasKey('production', $arrayIni);
+        $this->assertArrayNotHasKey('staging', $arrayIni);
+        $this->assertEquals('staging', $arrayIni['env']);
+        $this->assertEquals('foo', $arrayIni['production_key']);
+        $this->assertEquals('bar', $arrayIni['staging_key']);
+    }
+
     public function testFromStringParseSections()
     {
         $ini = <<<ECS
@@ -155,6 +172,32 @@ ECS;
 
         $arrayIni = $reader->fromString($ini);
 
+        $this->assertEquals('staging', $arrayIni['env']);
+        $this->assertEquals('foo', $arrayIni['production_key']);
+        $this->assertEquals('bar', $arrayIni['staging_key']);
+    }
+
+    public function testFromStringIgnoresNestingInSectionNamesWhenSectionsNotProcessed()
+    {
+        $ini = <<<ECS
+[environments.production]
+env='production'
+production_key='foo'
+
+[environments.staging]
+env='staging'
+staging_key='bar'
+ECS;
+        $reader = $this->reader;
+        $reader->setProcessSections(false);
+
+        $arrayIni = $reader->fromString($ini);
+
+        $this->assertArrayNotHasKey('environments.production', $arrayIni);
+        $this->assertArrayNotHasKey('environments.staging', $arrayIni);
+        $this->assertArrayNotHasKey('environments', $arrayIni);
+        $this->assertArrayNotHasKey('production', $arrayIni);
+        $this->assertArrayNotHasKey('staging', $arrayIni);
         $this->assertEquals('staging', $arrayIni['env']);
         $this->assertEquals('foo', $arrayIni['production_key']);
         $this->assertEquals('bar', $arrayIni['staging_key']);

--- a/test/Reader/IniTest.php
+++ b/test/Reader/IniTest.php
@@ -95,4 +95,26 @@ ECS;
         $this->assertEquals($arrayIni['bla']['foo']['baz'][0], 'foobaz1');
         $this->assertEquals($arrayIni['bla']['foo']['baz'][1], 'foobaz2');
     }
+
+    public function testFromFileParseSections()
+    {
+        $arrayIni = $this->reader->fromFile($this->getTestAssetPath('sections'));
+
+        $this->assertEquals($arrayIni['production']['env'], 'production');
+        $this->assertEquals($arrayIni['production']['production_key'], 'foo');
+        $this->assertEquals($arrayIni['staging : production']['env'], 'staging');
+        $this->assertEquals($arrayIni['staging : production']['staging_key'], 'bar');
+    }
+
+    public function testFromFileDontParseSections()
+    {
+        $reader = $this->reader;
+        $reader->setProcessSections(false);
+
+        $arrayIni = $reader->fromFile($this->getTestAssetPath('sections'));
+
+        $this->assertEquals($arrayIni['env'], 'staging');
+        $this->assertEquals($arrayIni['production_key'], 'foo');
+        $this->assertEquals($arrayIni['staging_key'], 'bar');
+    }
 }

--- a/test/Reader/IniTest.php
+++ b/test/Reader/IniTest.php
@@ -117,4 +117,46 @@ ECS;
         $this->assertEquals('foo', $arrayIni['production_key']);
         $this->assertEquals('bar', $arrayIni['staging_key']);
     }
+
+    public function testFromStringParseSections()
+    {
+        $ini = <<<ECS
+[production]
+env='production'
+production_key='foo'
+
+[staging : production]
+env='staging'
+staging_key='bar'
+
+ECS;
+        $arrayIni = $this->reader->fromString($ini);
+
+        $this->assertEquals('production', $arrayIni['production']['env']);
+        $this->assertEquals('foo', $arrayIni['production']['production_key']);
+        $this->assertEquals('staging', $arrayIni['staging : production']['env']);
+        $this->assertEquals('bar', $arrayIni['staging : production']['staging_key']);
+    }
+
+    public function testFromStringDontParseSections()
+    {
+        $ini = <<<ECS
+[production]
+env='production'
+production_key='foo'
+
+[staging : production]
+env='staging'
+staging_key='bar'
+
+ECS;
+        $reader = $this->reader;
+        $reader->setProcessSections(false);
+
+        $arrayIni = $reader->fromString($ini);
+
+        $this->assertEquals('staging', $arrayIni['env']);
+        $this->assertEquals('foo', $arrayIni['production_key']);
+        $this->assertEquals('bar', $arrayIni['staging_key']);
+    }
 }

--- a/test/Reader/TestAssets/Ini/nested-sections.ini
+++ b/test/Reader/TestAssets/Ini/nested-sections.ini
@@ -1,0 +1,7 @@
+[environments.production]
+env='production'
+production_key='foo'
+
+[environments.staging]
+env='staging'
+staging_key='bar'

--- a/test/Reader/TestAssets/Ini/sections.ini
+++ b/test/Reader/TestAssets/Ini/sections.ini
@@ -1,0 +1,7 @@
+[production]
+env='production'
+production_key='foo'
+
+[staging : production]
+env='staging'
+staging_key='bar'


### PR DESCRIPTION
By default the INI reader is processing sections. It is not possible to merge sections, which is the default behavior of [`parse_ini_file()`](https://www.php.net/parse_ini_file).

This PR introduces the protected property `$processSections` with a public getter and setter. It enables users to tell the reader not to process sections by setting `$processSections` to `false`. The default behavior of the reader does not change.

- [x] Are you creating a new feature? **Yes**
  - [x] Why is the new feature needed? What purpose does it serve? **See description above**
  - [x] How will users use the new feature? **See `docs/book/reader.md` in the INI section**
  - [x] Base your feature on the `develop` branch, and submit against that branch. **Check**
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests **Check**
  - [x] Add tests for the new feature. **Check**
  - [x] Add documentation for the new feature. **Check**
  - [x] Add a `CHANGELOG.md` entry for the new feature.
