### PR TITLE
add support to modify by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#59](https://github.com/zendframework/zend-config/pull/59)
+  `Zend\Config\Config` `offsetGet` allows reference access instead of yielding
+  Indirect modification of overloaded element of `Zend\Config\Config` has no effect
+  notice message.
 
 ### Deprecated
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -283,9 +283,15 @@ class Config implements Countable, Iterator, ArrayAccess
      * @param  mixed $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function &offsetGet($offset)
     {
-        return $this->__get($offset);
+        if (array_key_exists($offset, $this->data)) {
+            $value = &$this->data[$offset];
+        } else {
+            $value = null;
+        }
+
+        return $value;
     }
 
     /**

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -18,6 +18,20 @@ class ConfigTest extends TestCase
 {
     protected $iniFileConfig;
     protected $iniFileNested;
+    /** @var array */
+    private $all;
+    /** @var array */
+    private $numericData;
+    /** @var array */
+    private $menuData1;
+    /** @var array */
+    private $toCombineA;
+    /** @var array */
+    private $toCombineB;
+    /** @var array */
+    private $leadingdot;
+    /** @var array */
+    private $invalidkey;
 
     public function setUp()
     {

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -685,5 +685,8 @@ class ConfigTest extends TestCase
 
         $this->assertEquals('secret', $config['db']['pass']);
         $this->assertNull($config['db']['pass2']);
+
+        // this tests that 'pass2' key is not created
+        $this->assertEquals('not-set', $config['db']->get('pass2', 'not-set'));
     }
 }

--- a/test/ConfigTest.php
+++ b/test/ConfigTest.php
@@ -664,4 +664,26 @@ class ConfigTest extends TestCase
 
         $this->assertInstanceOf(TestAssets\ExtendedConfig::class, $config->node);
     }
+
+    /**
+     * @see https://github.com/zendframework/zend-config/pull/59
+     */
+    public function testAllowModificationByReference()
+    {
+        $config = new Config($this->all, true);
+
+        $closure = function (&$property, $value) {
+            if ($property === null) {
+                return;
+            }
+
+            $property = $value;
+        };
+
+        $closure($config['db']['pass'], 'secret');
+        $closure($config['db']['pass2'], 'secret');
+
+        $this->assertEquals('secret', $config['db']['pass']);
+        $this->assertNull($config['db']['pass2']);
+    }
 }


### PR DESCRIPTION
This adds resolution to typical notice seen:

> Indirect modification of overloaded element of `Zend\Config\Config` has no effect 

Example:

```php

        $config = new Config($this->all, true);

        $closure = function (&$property, $value) {
            if ($property === null) {
                return;
            }

            $property = $value;
        };

        // updates $config['db']['pass'] value to 'secret'
        $closure($config['db']['pass'], 'secret');
        // $config['db']['pass2'] is not present and will not be created
        $closure($config['db']['pass2'], 'secret');
```

This requires PHP 5.3.4 :

> Update: This problem was fixed in PHP 5.3.4 and ArrayAccess now works as expected:
> 
> Starting with PHP 5.3.4, the prototype checks were relaxed and it's possible for  implementations of this method to return by reference. This makes indirect modifications to the overloaded array dimensions of ArrayAccess objects possible.
> 
> - https://stackoverflow.com/a/2881533/2314626

<!--
Provide a narrative description of what you are trying to accomplish:

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

-->