### PR TITLE
Add yml as alternative extension for yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#58](https://github.com/zendframework/zend-config/pull/58) adds
   `$processSections` to INI reader, allowing control over whether sections
   should be parsed or not
+- [#63](https://github.com/zendframework/zend-config/pull/63) adds .yml to
+  Zend\Config\Factory as an alternative extension for yaml
 
 ### Changed
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,6 +37,7 @@ class Factory
         'json'        => 'json',
         'xml'         => 'xml',
         'yaml'        => 'yaml',
+        'yml'         => 'yaml',
         'properties'  => 'javaproperties',
     ];
 
@@ -52,6 +53,7 @@ class Factory
         'json' => 'json',
         'xml'  => 'xml',
         'yaml' => 'yaml',
+        'yml'  => 'yaml',
     ];
 
     /**


### PR DESCRIPTION
This PR addes  `.yml` as an alternative extension for `.yaml` to static config factory.
It is used for reader and writer selection in `Zend\Config\Factory` only and does not affect readers or writers.
