### PR TITLE
Use lowercase `config` key to get configuration from container

### DIFF
--- a/src/AbstractConfigFactory.php
+++ b/src/AbstractConfigFactory.php
@@ -61,7 +61,7 @@ class AbstractConfigFactory implements AbstractFactoryInterface
             return true;
         }
 
-        if (! $container->has('Config')) {
+        if (! $container->has('config')) {
             return false;
         }
 
@@ -70,7 +70,7 @@ class AbstractConfigFactory implements AbstractFactoryInterface
             return false;
         }
 
-        $config = $container->get('Config');
+        $config = $container->get('config');
         return isset($config[$key]);
     }
 
@@ -107,7 +107,7 @@ class AbstractConfigFactory implements AbstractFactoryInterface
             return $this->configs[$key];
         }
 
-        $config = $container->get('Config');
+        $config = $container->get('config');
         $this->configs[$requestedName] = $this->configs[$key] = $config[$key];
         return $config[$key];
     }

--- a/test/AbstractConfigFactoryTest.php
+++ b/test/AbstractConfigFactoryTest.php
@@ -52,7 +52,7 @@ class AbstractConfigFactoryTest extends TestCase
                 AbstractConfigFactory::class,
             ],
             'services' => [
-                'Config' => $this->config,
+                'config' => $this->config,
             ],
         ]);
         $smConfig->configureServiceManager($this->serviceManager);


### PR DESCRIPTION
- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->
